### PR TITLE
chore(issue-6): add link to github repository to version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ARMHF_PROJECT_NAME = ez80op_linux_armhf
 ARM64_PROJECT_NAME = ez80op_linux_aarch64
 Z80_PROJECT_NAME = ez80op_agon_z80
 GIT_INFO := "$(shell git describe --always --tags)"
+BUILD_YEAR := $(shell date +'%Y')
 
 # Architecture-Specific Compilers and Flags
 X86_CC = gcc

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,31 @@
+/* 
+/ Title:		   ez80op
+/
+/ Description:     opcode typdef implementation
+/
+/ Author:          Andy McCall, mailme@andymccall.co.uk
+/
+/ Created:		   Fri 30 Aug 15:37:58 BST 2024
+/ Last Updated:	   
+/
+/ Modinfo:
+*/
+
+#ifndef _CONSTANTS_H_
+#define _CONSTANTS_H_
+
+#define PROGRAM_NAME "ez80op"
+
+#define GIT_REPOSITORY "https://github.com/andymccall/ez80op"
+
+#ifndef GIT_INFO
+#define GIT_INFO "unknown"
+#endif
+
+#ifndef BUILD_YEAR
+#define BUILD_YEAR "2024"
+#endif
+
+#define AUTHOR "Andy McCall"
+
+#endif /* !_CONSTANTS_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -22,13 +22,11 @@
 #include "config.h"
 #include "opcode.h"
 #include "data.h"
-
-#ifndef GIT_INFO
-#define GIT_INFO "unknown"
-#endif
+#include "constants.h"
 
 void printVersion(void) {
-    printf("ez80op version %d.%d-%s, (C)2024 - Andy McCall\r\n",VERSION,REVISION,GIT_INFO);
+    printf("%s version %d.%d-%s, (C)%s - %s\r\n",PROGRAM_NAME,VERSION,REVISION,GIT_INFO,BUILD_YEAR,AUTHOR);
+    printf("%s\r\n",GIT_REPOSITORY);
 }
 
 void printHelp(void) {


### PR DESCRIPTION
Output is now:

```
ez80op version 0.1-5d71b39, (C)2024 - Andy McCall
https://github.com/andymccall/ez80op
```

Also reworked some constants for other version information and made the year automatically update via the Makefile.